### PR TITLE
Formatting plus add MacCatalyst exclusion handler methods

### DIFF
--- a/src/FlagstoneUI.Core/Controls/BorderlessEditor.cs
+++ b/src/FlagstoneUI.Core/Controls/BorderlessEditor.cs
@@ -6,21 +6,21 @@ public partial class BorderlessEditor : Editor
 	{
 		var transparentBackgroundSetter = new Setter
 		{
-			Property = BackgroundColorProperty,
-			Value = Colors.Transparent
+			Property	= BackgroundColorProperty,
+			Value		= Colors.Transparent
 		};
 
 		var focusedTrigger = new Trigger(typeof(BorderlessEditor))
 		{
-			Property = IsFocusedProperty,
-			Value = true
+			Property	= IsFocusedProperty,
+			Value		= true
 		};
 		focusedTrigger.Setters.Add(transparentBackgroundSetter);
 
 		var hoverTrigger = new Trigger(typeof(BorderlessEditor))
 		{
-			Property = IsFocusedProperty,
-			Value = true
+			Property	= IsFocusedProperty,
+			Value		= true
 		};
 		hoverTrigger.Setters.Add(transparentBackgroundSetter);
 
@@ -30,7 +30,7 @@ public partial class BorderlessEditor : Editor
 
 	internal static partial void RegisterHandler();
 
-#if !(ANDROID || WINDOWS || IOS)
+#if !(ANDROID || WINDOWS || IOS || MACCATALYST)
 	internal static partial void RegisterHandler() { }
 #endif
 }

--- a/src/FlagstoneUI.Core/Controls/BorderlessEntry.cs
+++ b/src/FlagstoneUI.Core/Controls/BorderlessEntry.cs
@@ -6,21 +6,21 @@ public partial class BorderlessEntry : Entry
 	{
 		var transparentBackgroundSetter = new Setter
 		{
-			Property = BackgroundColorProperty,
-			Value = Colors.Transparent
+			Property	= BackgroundColorProperty,
+			Value		= Colors.Transparent
 		};
 
 		var focusedTrigger = new Trigger(typeof(BorderlessEntry))
 		{
-			Property = IsFocusedProperty,
-			Value = true
+			Property	= IsFocusedProperty,
+			Value		= true
 		};
 		focusedTrigger.Setters.Add(transparentBackgroundSetter);
 
 		var hoverTrigger = new Trigger(typeof(BorderlessEntry))
 		{
-			Property = IsFocusedProperty,
-			Value = true
+			Property	= IsFocusedProperty,
+			Value		= true
 		};
 		hoverTrigger.Setters.Add(transparentBackgroundSetter);
 
@@ -30,7 +30,7 @@ public partial class BorderlessEntry : Entry
 
 	internal static partial void RegisterHandler();
 
-#if !(ANDROID || WINDOWS || IOS)
+#if !(ANDROID || WINDOWS || IOS || MACCATALYST)
 	internal static partial void RegisterHandler() { }
 #endif
 }


### PR DESCRIPTION
This pull request makes a small update to platform checks in the `BorderlessEditor` and `BorderlessEntry` controls to include support for the `MACCATALYST` platform.

- Platform Support Update:
  * Updated the platform conditional compilation in `BorderlessEditor.cs` and `BorderlessEntry.cs` to include `MACCATALYST` in the list of platforms where the `RegisterHandler` method is not defined. [[1]](diffhunk://#diff-d81ab21438847582860db82761de6c2243f97610387ec26229cc17566a6b44dfL33-R33) [[2]](diffhunk://#diff-dec9bf23273c64d207e94a7e92bab7f00e8d6441e40a61bcae0959f098406e9bL33-R33)…r method

