### PR TITLE
WIP: Add main blocks

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -108,6 +108,7 @@ dotnet format Flagstone.UI.sln --no-restore --exclude-diagnostics CA1822
 - **Themes**: Implement platform-agnostic styles in `Theme.xaml`. Themes can use direct values, app resources, or design tokens.
 - **Blocks**: High-level screens go in `src/FlagstoneUI.Blocks/Blocks` and depend on Core controls.
 - **Optional: Design Tokens**: Some themes (like Material) use tokens in `src/FlagstoneUI.Core/Styles/Tokens.xaml` as an implementation detail. Tokens are consumed via `DynamicResource`.
+- **XAML Data Binding**: In .NET MAUI library projects that multi-target net10.0 alongside platform-specific TFMs (net10.0-android, net10.0-ios, etc.), the XAML source generator does NOT produce strongly-typed x:Name fields for the plain net10.0 TFM. Code-behind must not directly reference XAML-generated fields (e.g., this.SignInButton.Text). Instead, use XAML data bindings with x:Reference to the parent control and BindingContext to propagate property values to child controls. This keeps net10.0 compilable (needed for unit testing without a device/emulator) while still working on all platform TFMs.
 
 ## Integration Points
 

--- a/docs/project/blocks-roadmap.md
+++ b/docs/project/blocks-roadmap.md
@@ -109,7 +109,7 @@ These blocks cover useful but less universally-required patterns. They extend Fl
 | Block | Description | Notes |
 |---|---|---|
 | **Activity Feed / Timeline** | Chronological list with avatar, action text, timestamp, and optional image | Useful for social or productivity apps |
-| **Comments / Reviews List** | User comment items with avatar, rating (optional), and body text | Common in e-commerce and content apps |
+| **Comments / Reviews List** | User comment items with avatar, rating (from Community Toolkit), and body text | Common in e-commerce and content apps |
 | **Image Grid / Gallery** | Uniform grid of images with optional caption overlay | Requires platform image handling |
 
 ### Commerce

--- a/samples/FlagstoneUI.SampleApp/AppShell.xaml
+++ b/samples/FlagstoneUI.SampleApp/AppShell.xaml
@@ -7,8 +7,7 @@
     xmlns:page="clr-namespace:FlagstoneUI.SampleApp.Pages"
     xmlns:converters="clr-namespace:FlagstoneUI.SampleApp.Converters"
     xmlns:vm="clr-namespace:FlagstoneUI.SampleApp.ViewModels"
-    Title="FlagstoneUI.SampleApp"
-    FlyoutBehavior="Disabled">
+    Title="FlagstoneUI.SampleApp">
 
 
 
@@ -19,7 +18,7 @@
         Route="ControlsShowcase" />
 
     <!-- Hidden routes for future use -->
-    <!--
+    
     <FlyoutItem Title="Home" Icon="icon_home.png">
         <ShellContent
             Title="Main"
@@ -36,6 +35,6 @@
                 Icon="signin_icon.png"/>
         </Tab>
     </FlyoutItem>
-    -->
+    
 
 </Shell>

--- a/samples/FlagstoneUI.SampleApp/Pages/ControlShowcasePage.xaml
+++ b/samples/FlagstoneUI.SampleApp/Pages/ControlShowcasePage.xaml
@@ -175,6 +175,7 @@
 
       <fs:FsEditor Placeholder="Enter multi-line text here"
                    x:Name="MultiLineEditor"
+                    Text="{Binding EditorText, Mode=TwoWay}"
                    Style="{DynamicResource OutlinedEditor}" />
 
       <Grid>
@@ -183,6 +184,7 @@
                      x:Name="AiEditor"
                      Focused="AiEditor_OnFocused"
                      Unfocused="AiEditor_OnUnfocused"
+                     Text="{Binding EditorText, Mode=TwoWay}"
                      Style="{DynamicResource AiEditorStyle}" />
 
         <Button Background="Goldenrod"

--- a/samples/FlagstoneUI.SampleApp/Pages/ControlShowcasePage.xaml
+++ b/samples/FlagstoneUI.SampleApp/Pages/ControlShowcasePage.xaml
@@ -88,13 +88,13 @@
         <!-- Filled Entry (Default) -->
         <fs:FsEntry Placeholder="Filled Entry (Default)"
                     x:Name="FilledEntry"
-                    TextChanged="OnEntryTextChanged" />
+                    Text="{Binding EntryText, Mode=TwoWay}" />
 
         <!-- Outlined Entry -->
         <fs:FsEntry Placeholder="Outlined Entry"
                     Style="{StaticResource OutlinedEntry}"
                     x:Name="OutlinedEntry"
-                    TextChanged="OnEntryTextChanged" />
+                    Text="{Binding EntryText}" />
 
         <!-- Entry with Text -->
         <fs:FsEntry Placeholder="Entry with preset text"
@@ -118,7 +118,7 @@
 
         <!-- Entry State Feedback -->
         <Label x:Name="EntryFeedbackLabel"
-               Text="Type in any entry to see feedback..."
+               Text="{Binding EntryText}"
                FontSize="12"
                TextColor="{AppThemeBinding Light={DynamicResource Color.OnSurfaceVariant}, Dark={DynamicResource Color.OnSurfaceVariant.Dark}}"
                Margin="0,8,0,0" />
@@ -135,7 +135,7 @@
         <!-- Default Entry -->
         <fs:FsEntry Placeholder="Default Entry"
                     x:Name="DefaultEntry"
-                    TextChanged="OnEntryTextChanged" />
+                    Text="{Binding EntryText}" />
 
         <!-- Entry with Text -->
         <fs:FsEntry Placeholder="Entry with preset text"
@@ -156,7 +156,7 @@
 
         <!-- Entry State Feedback -->
         <Label x:Name="EntryFeedbackLabelAlt"
-               Text="Type in any entry to see feedback..."
+               Text="{Binding EntryText}"
                FontSize="12"
                TextColor="{AppThemeBinding Light={DynamicResource Color.OnSurfaceVariant}, Dark={DynamicResource Color.OnSurfaceVariant.Dark}}"
                Margin="0,8,0,0" />
@@ -200,6 +200,13 @@
         </Button>
 
       </Grid>
+
+      <!-- Entry State Feedback -->
+      <Label x:Name="EditorStateFeedbackLabel"
+       Text="{Binding EditorText}"
+       FontSize="12"
+       TextColor="{AppThemeBinding Light={DynamicResource Color.OnSurfaceVariant}, Dark={DynamicResource Color.OnSurfaceVariant.Dark}}"
+       Margin="0,8,0,0" />
 
       <!-- Divider -->
       <BoxView HeightRequest="1"

--- a/samples/FlagstoneUI.SampleApp/Pages/ControlShowcasePage.xaml.cs
+++ b/samples/FlagstoneUI.SampleApp/Pages/ControlShowcasePage.xaml.cs
@@ -27,17 +27,17 @@ public partial class ControlsShowcasePage : ContentPage
 		}
 	}
 
-	private void OnEntryTextChanged(object sender, TextChangedEventArgs e)
-	{
-		if (sender is Microsoft.Maui.Controls.Entry entry)
-		{
-			var message = $"Text changed: '{e.NewTextValue}' (Length: {e.NewTextValue?.Length ?? 0})";
+	////private void OnEntryTextChanged(object sender, TextChangedEventArgs e)
+	////{
+	////	if (sender is Microsoft.Maui.Controls.Entry entry)
+	////	{
+	////		var message = $"Text changed: '{e.NewTextValue}' (Length: {e.NewTextValue?.Length ?? 0})";
 
-			// Update both feedback labels (only one will be visible at a time)
-			EntryFeedbackLabel?.Text = message;
-			EntryFeedbackLabelAlt?.Text = message;
-		}
-	}
+	////		// Update both feedback labels (only one will be visible at a time)
+	////		EntryFeedbackLabel?.Text = message;
+	////		EntryFeedbackLabelAlt?.Text = message;
+	////	}
+	////}
 
 	readonly FsEditorBorderAnimation _animation = new()
 	{

--- a/samples/FlagstoneUI.SampleApp/Pages/SignInPage.xaml
+++ b/samples/FlagstoneUI.SampleApp/Pages/SignInPage.xaml
@@ -3,12 +3,17 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="FlagstoneUI.SampleApp.Pages.SignInPage"
              xmlns:fs="clr-namespace:FlagstoneUI.Blocks.Authentication;assembly=FlagstoneUI.Blocks"
+             xmlns:vm="clr-namespace:FlagstoneUI.SampleApp.ViewModels"
+             x:DataType="vm:SignInViewModel"
              Title="SignInPage">
     <FlexLayout Direction="Column"
                 AlignItems="Center"
                 JustifyContent="Center"
                 Padding="20">
         <fs:SigninForm x:Name="SignInForm"
-                       UsernamePlaceholder="Please enter a username"/>
+                       UsernamePlaceholder="Please enter a username"
+                       Username="{Binding Email}"
+                       Password="{Binding Password}"
+                       SigninCommand="{Binding SignInCommand}"/>
     </FlexLayout>
 </ContentPage>

--- a/samples/FlagstoneUI.SampleApp/Pages/SignInPage.xaml.cs
+++ b/samples/FlagstoneUI.SampleApp/Pages/SignInPage.xaml.cs
@@ -1,3 +1,5 @@
+﻿using FlagstoneUI.SampleApp.ViewModels;
+
 namespace FlagstoneUI.SampleApp.Pages;
 
 public partial class SignInPage : ContentPage
@@ -5,5 +7,6 @@ public partial class SignInPage : ContentPage
 	public SignInPage()
 	{
 		InitializeComponent();
+		SignInForm.BindingContext = new SignInViewModel();
 	}
 }

--- a/samples/FlagstoneUI.SampleApp/ViewModels/ControlsShowcaseViewModel.cs
+++ b/samples/FlagstoneUI.SampleApp/ViewModels/ControlsShowcaseViewModel.cs
@@ -3,7 +3,7 @@ using System.Runtime.CompilerServices;
 
 namespace FlagstoneUI.SampleApp.ViewModels;
 
-public class ControlsShowcaseViewModel : INotifyPropertyChanged
+public partial class ControlsShowcaseViewModel : INotifyPropertyChanged
 {
 	private string _selectedTheme = "Material";
 
@@ -39,6 +39,36 @@ public class ControlsShowcaseViewModel : INotifyPropertyChanged
 		"Minty",
 		"Brite"
 	];
+
+	private string _entryText = string.Empty;
+	public string EntryText
+	{
+		get => _entryText;
+		set
+		{
+			if (_entryText == value)
+			{
+				return;
+			}
+			_entryText = value;
+			OnPropertyChanged();
+		}
+	}
+
+	private string _editorText = string.Empty;
+	public string EditorText
+	{
+		get => _editorText;
+		set
+		{
+			if (_editorText == value)
+			{
+				return;
+			}
+			_editorText = value;
+			OnPropertyChanged();
+		}
+	}
 
 	protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
 	{

--- a/samples/FlagstoneUI.SampleApp/ViewModels/SignInViewModel.cs
+++ b/samples/FlagstoneUI.SampleApp/ViewModels/SignInViewModel.cs
@@ -37,8 +37,14 @@ public partial class SignInViewModel : INotifyPropertyChanged
 		}
 	}
 
-	public ICommand SignInCommand => new Command(async () => await SignIn());
+	private readonly ICommand _signInCommand;
 
+	public SignInViewModel()
+	{
+		_signInCommand = new Command(async () => await SignIn());
+	}
+
+	public ICommand SignInCommand => _signInCommand;
 	public async Task SignIn()
 	{
 		// Implement sign-in logic here

--- a/samples/FlagstoneUI.SampleApp/ViewModels/SignInViewModel.cs
+++ b/samples/FlagstoneUI.SampleApp/ViewModels/SignInViewModel.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Windows.Input;
+
+namespace FlagstoneUI.SampleApp.ViewModels;
+
+public partial class SignInViewModel : INotifyPropertyChanged
+{
+	private string _email = string.Empty;
+	public string Email
+	{
+		get => _email;
+		set
+		{
+			if (_email != value)
+			{
+				_email = value;
+				OnPropertyChanged();
+			}
+		}
+	}
+
+	private string _password = string.Empty;
+	public string Password
+	{
+		get => _password;
+		set
+		{
+			if (_password != value)
+			{
+				_password = value;
+				OnPropertyChanged();
+			}
+		}
+	}
+
+	public ICommand SignInCommand => new Command(async () => await SignIn());
+
+	public async Task SignIn()
+	{
+		// Implement sign-in logic here
+		await App.Current.Windows[0].Page.DisplayAlertAsync("Sign In", $"Email: {Email}\nPassword: {Password}", "OK");
+	}
+
+	public event PropertyChangedEventHandler? PropertyChanged;
+	protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+	{
+		PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+	}
+}

--- a/src/FlagstoneUI.Blocks/Authentication/SignInForm.xaml
+++ b/src/FlagstoneUI.Blocks/Authentication/SignInForm.xaml
@@ -1,23 +1,24 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-			 xmlns:fs="clr-namespace:FlagstoneUI.Core.Controls;assembly=FlagstoneUI.Core"
-			 xmlns:local="clr-namespace:FlagstoneUI.Blocks.Authentication"
-             x:Class="FlagstoneUI.Blocks.Authentication.SigninForm">
-	<fs:FsCard>
+						 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+						 xmlns:fs="clr-namespace:FlagstoneUI.Core.Controls;assembly=FlagstoneUI.Core"
+						 xmlns:local="clr-namespace:FlagstoneUI.Blocks.Authentication"
+						 x:Class="FlagstoneUI.Blocks.Authentication.SigninForm"
+						 x:Name="Self">
+	<fs:FsCard x:DataType="local:SigninForm"
+						 BindingContext="{x:Reference Self}">
 		<FlexLayout Direction="Column"
 					AlignItems="Center"
 					JustifyContent="SpaceAround">
-			<fs:FsEntry x:Name="UsernameEntry"
-						Placeholder="Username"
+			<fs:FsEntry Placeholder="{Binding UsernamePlaceholder}"
+						Text="{Binding Username, Mode=TwoWay}"
 						WidthRequest="250" />
 
-			<fs:FsEntry x:Name="PasswordEntry"
-						Placeholder="Password"
+			<fs:FsEntry Placeholder="{Binding PasswordPlaceholder}"
+						Text="{Binding Password, Mode=TwoWay}"
 						IsPassword="True"/>
 
-			<fs:FsButton x:Name="SignInButton"
-						Text="Sign In"
+			<fs:FsButton Text="{Binding SignInButtonText}"
 						WidthRequest="250"
 						Clicked="OnSigninClicked" />
 		</FlexLayout>

--- a/src/FlagstoneUI.Blocks/Authentication/SignInForm.xaml.cs
+++ b/src/FlagstoneUI.Blocks/Authentication/SignInForm.xaml.cs
@@ -91,9 +91,9 @@ public partial class SigninForm : ContentView
 	/// <summary>
 	/// Gets or sets the command executed when the sign-in button is clicked.
 	/// </summary>
-	public ICommand SigninCommand
+	public ICommand? SigninCommand
 	{
-		get => (ICommand)GetValue(SigninCommandProperty);
+		get => (ICommand?)GetValue(SigninCommandProperty);
 		set => SetValue(SigninCommandProperty, value);
 	}
 	#endregion

--- a/src/FlagstoneUI.Blocks/Authentication/SignInForm.xaml.cs
+++ b/src/FlagstoneUI.Blocks/Authentication/SignInForm.xaml.cs
@@ -52,7 +52,7 @@ public partial class SigninForm : ContentView
 	/// <remarks>This property defines the text displayed in the username input field of the sign-in
 	/// form. The default value is an empty string.</remarks>
 	public static readonly BindableProperty UsernameProperty = BindableProperty.Create(
-		nameof(Username), typeof(string), typeof(SigninForm), string.Empty);
+		nameof(Username), typeof(string), typeof(SigninForm), string.Empty, BindingMode.TwoWay);
 	/// <summary>
 	/// Gets or sets the text displayed in the username input field.
 	/// </summary>

--- a/src/FlagstoneUI.Blocks/Authentication/SignInForm.xaml.cs
+++ b/src/FlagstoneUI.Blocks/Authentication/SignInForm.xaml.cs
@@ -70,7 +70,7 @@ public partial class SigninForm : ContentView
 	/// <remarks>This property defines the text displayed in the password input field of the sign-in
 	/// form. The default value is an empty string.</remarks>
 	public static readonly BindableProperty PasswordProperty = BindableProperty.Create(
-		nameof(Password), typeof(string), typeof(SigninForm), string.Empty);
+		nameof(Password), typeof(string), typeof(SigninForm), string.Empty, BindingMode.TwoWay);
 	/// <summary>
 	/// Gets or sets the text displayed in the password input field.
 	/// </summary>

--- a/src/FlagstoneUI.Blocks/Authentication/SignInForm.xaml.cs
+++ b/src/FlagstoneUI.Blocks/Authentication/SignInForm.xaml.cs
@@ -1,4 +1,6 @@
-﻿namespace FlagstoneUI.Blocks.Authentication;
+﻿using System.Windows.Input;
+
+namespace FlagstoneUI.Blocks.Authentication;
 
 public partial class SigninForm : ContentView
 {
@@ -7,33 +9,122 @@ public partial class SigninForm : ContentView
 		InitializeComponent();
 	}
 
-    #region UsernamePlaceholder Property
+	#region UsernamePlaceholder Property
 	/// <summary>
 	/// Identifies the bindable property for the username placeholder text.
 	/// </summary>
 	/// <remarks>This property defines the placeholder text displayed in the username input field of the sign-in
 	/// form. The default value is "Username".</remarks>
-    public static readonly BindableProperty UsernamePlaceholderProperty = BindableProperty.Create(
-		nameof(UsernamePlaceholder), typeof(string), typeof(SigninForm), "Username", propertyChanged: UsernamePlaceholderPropertyChanged);
+	public static readonly BindableProperty UsernamePlaceholderProperty = BindableProperty.Create(
+		nameof(UsernamePlaceholder), typeof(string), typeof(SigninForm), "Username");
 	/// <summary>
 	/// Gets or sets the placeholder text displayed in the username input field.
 	/// </summary>
 	public string UsernamePlaceholder
-    {
+	{
 		get => (string)GetValue(UsernamePlaceholderProperty);
 		set => SetValue(UsernamePlaceholderProperty, value);
-    }
-	private static void UsernamePlaceholderPropertyChanged(BindableObject bindable, object oldValue, object newValue)
-	{
-		if (bindable is SigninForm signinForm && newValue is string newPlaceholder)
-		{
-			signinForm.UsernameEntry.Placeholder = newPlaceholder;
-		}
 	}
-    #endregion
+	#endregion
 
-    public void OnSigninClicked(object sender, EventArgs e)
+	#region PasswordPlaceholder Property
+	/// <summary>
+	/// Identifies the bindable property for the password placeholder text.
+	/// </summary>
+	/// <remarks>This property defines the placeholder text displayed in the password input field of the sign-in
+	/// form. The default value is "Password".</remarks>
+	public static readonly BindableProperty PasswordPlaceholderProperty = BindableProperty.Create(
+		nameof(PasswordPlaceholder), typeof(string), typeof(SigninForm), "Password");
+	/// <summary>
+	/// Gets or sets the placeholder text displayed in the password input field.
+	/// </summary>
+	public string PasswordPlaceholder
 	{
-		
-    }
+		get => (string)GetValue(PasswordPlaceholderProperty);
+		set => SetValue(PasswordPlaceholderProperty, value);
+	}
+	#endregion
+
+	#region Username Property
+	/// <summary>
+	/// Identifies the bindable property for the username text.
+	/// </summary>
+	/// <remarks>This property defines the text displayed in the username input field of the sign-in
+	/// form. The default value is an empty string.</remarks>
+	public static readonly BindableProperty UsernameProperty = BindableProperty.Create(
+		nameof(Username), typeof(string), typeof(SigninForm), string.Empty);
+	/// <summary>
+	/// Gets or sets the text displayed in the username input field.
+	/// </summary>
+	public string Username
+	{
+		get => (string)GetValue(UsernameProperty);
+		set => SetValue(UsernameProperty, value);
+	}
+	#endregion
+
+	#region Password Property
+	/// <summary>
+	/// Identifies the bindable property for the password text.
+	/// </summary>
+	/// <remarks>This property defines the text displayed in the password input field of the sign-in
+	/// form. The default value is an empty string.</remarks>
+	public static readonly BindableProperty PasswordProperty = BindableProperty.Create(
+		nameof(Password), typeof(string), typeof(SigninForm), string.Empty);
+	/// <summary>
+	/// Gets or sets the text displayed in the password input field.
+	/// </summary>
+	public string Password
+	{
+		get => (string)GetValue(PasswordProperty);
+		set => SetValue(PasswordProperty, value);
+	}
+	#endregion
+
+	#region SigninCommand Property
+	/// <summary>
+	/// Identifies the bindable property for the sign-in command.
+	/// </summary>
+	/// <remarks>This property defines the command executed when the sign-in button is clicked.</remarks>
+	public static readonly BindableProperty SigninCommandProperty = BindableProperty.Create(
+		nameof(SigninCommand), typeof(ICommand), typeof(SigninForm), null);
+	/// <summary>
+	/// Gets or sets the command executed when the sign-in button is clicked.
+	/// </summary>
+	public ICommand SigninCommand
+	{
+		get => (ICommand)GetValue(SigninCommandProperty);
+		set => SetValue(SigninCommandProperty, value);
+	}
+	#endregion
+
+	#region SignInClicked Event
+	/// <summary>
+	/// Occurs when the sign-in button is clicked.
+	/// </summary>
+	public event EventHandler? SignInClicked;
+	#endregion
+
+	#region SignInButtonText Property
+	/// <summary>
+	/// Identifies the bindable property for the sign-in button text.
+	/// </summary>
+	/// <remarks>This property defines the text displayed on the sign-in button. The default value is "Sign In".</remarks>
+	public static readonly BindableProperty SignInButtonTextProperty = BindableProperty.Create(
+		nameof(SignInButtonText), typeof(string), typeof(SigninForm), "Sign In");
+	/// <summary>
+	/// Gets or sets the text displayed on the sign-in button.
+	/// </summary>
+	public string SignInButtonText
+	{
+		get => (string)GetValue(SignInButtonTextProperty);
+		set => SetValue(SignInButtonTextProperty, value);
+	}
+	#endregion
+
+	public void OnSigninClicked(object sender, EventArgs e)
+	{
+		SignInClicked?.Invoke(this, e);
+		SigninCommand?.Execute(null);
+	}
 }

--- a/src/FlagstoneUI.Core/Controls/FsEditor.xaml.cs
+++ b/src/FlagstoneUI.Core/Controls/FsEditor.xaml.cs
@@ -15,7 +15,7 @@ public partial class FsEditor : ContentView
 	public FsEditor()
 	{
 		InitializeComponent();
-		ViewWrapper.BindingContext = this;
+		WrapperBorder.BindingContext = this;
 		_borderShape = new RoundRectangle { CornerRadius = CornerRadius };
     }
 

--- a/src/FlagstoneUI.Core/Controls/FsEntry.xaml.cs
+++ b/src/FlagstoneUI.Core/Controls/FsEntry.xaml.cs
@@ -15,7 +15,7 @@ public partial class FsEntry : ContentView
 	public FsEntry()
 	{
 		InitializeComponent();
-		ViewWrapper.BindingContext = this;
+		WrapperBorder.BindingContext = this;
 		_borderShape = new RoundRectangle { CornerRadius = CornerRadius };
     }
 


### PR DESCRIPTION
## Summary

This item is a work in progress and addresses the need for the blocks as identified in `blocks-roadmap.md`.

However during development a critical bug was discovered in the bindings for `FsEntry` and `FsEditor`. The bindable properties in the release versions of these controls do not currently work and therefore it is necessary to ship immediately and complete the blocks later.

## Changes

- Partial improvement to the Signin form block
- Update showcase page to use bindings (retained previous event based approach in comments as this is a reference rather than a production app, and could be useful for people)
- Fixed bug in core library where wrong binding context was set to contenview rather than control wrapper

