### PR TITLE
Fix floating tabbar

### DIFF
--- a/docs/controls/FsTabBar.md
+++ b/docs/controls/FsTabBar.md
@@ -352,6 +352,7 @@ Note: on iOS, content that scales beyond the bar's bounds (e.g. the pill animati
 
 ## See Also
 
+- [Floating tab bar — iOS pass-through WIP notes](floating-tabbar-ios-passthrough-notes.md) — hand-off notes for the undocked-bar navigation + iOS hit-testing work (delete once verified)
 - [FsShell Control](FsShell.md) — the host
 - [ADR012 — FsShell: Stylable Shell Chrome via Subclass](../decisions/adr012-fsshell.md)
 - [ADR013 — Shell Animations](../decisions/adr013-shell-animations.md) — context for the "bring your own bar" animation story this control now partly fulfils

--- a/docs/controls/FsTabBar.md
+++ b/docs/controls/FsTabBar.md
@@ -352,7 +352,6 @@ Note: on iOS, content that scales beyond the bar's bounds (e.g. the pill animati
 
 ## See Also
 
-- [Floating tab bar — iOS pass-through WIP notes](floating-tabbar-ios-passthrough-notes.md) — hand-off notes for the undocked-bar navigation + iOS hit-testing work (delete once verified)
 - [FsShell Control](FsShell.md) — the host
 - [ADR012 — FsShell: Stylable Shell Chrome via Subclass](../decisions/adr012-fsshell.md)
 - [ADR013 — Shell Animations](../decisions/adr013-shell-animations.md) — context for the "bring your own bar" animation story this control now partly fulfils

--- a/samples/FlagstoneUI.SampleApp/App.xaml.cs
+++ b/samples/FlagstoneUI.SampleApp/App.xaml.cs
@@ -12,7 +12,7 @@ public partial class App : Application
 
 	protected override Window CreateWindow(IActivationState? activationState)
 	{
-		return new Window(new DemoShell());
+		return new Window(new FloatingShell()); //DemoShell());
 	}
 
 	public static void SwitchTheme(string theme)

--- a/samples/FlagstoneUI.SampleApp/App.xaml.cs
+++ b/samples/FlagstoneUI.SampleApp/App.xaml.cs
@@ -12,7 +12,7 @@ public partial class App : Application
 
 	protected override Window CreateWindow(IActivationState? activationState)
 	{
-		return new Window(new FloatingShell()); //DemoShell());
+		return new Window(new /*FloatingShell()); */DemoShell());
 	}
 
 	public static void SwitchTheme(string theme)

--- a/samples/FlagstoneUI.SampleApp/Controls/FloatingTabBar.xaml
+++ b/samples/FlagstoneUI.SampleApp/Controls/FloatingTabBar.xaml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<fs:FsTabBarBase xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:fs="clr-namespace:FlagstoneUI.Core.Controls;assembly=FlagstoneUI.Core"
+             xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+             x:Class="FlagstoneUI.SampleApp.Controls.FloatingTabBar">
+  <!-- The tab template is set on the bar itself (not as BindableLayout.ItemTemplate) so the
+       FsTabBarBase template selector can wrap each item in the tap gesture that drives navigation.
+       FsShell.TabBarItemTemplate is only forwarded to the default FsTabBar, not to a custom bar. -->
+  <fs:FsTabBarBase.ItemTemplate>
+    <DataTemplate x:DataType="fs:FsTabContext">
+      <HorizontalStackLayout HorizontalOptions="End"
+                             Spacing="5">
+        <Label Text="{Binding Title}"
+               HorizontalOptions="End"
+               HorizontalTextAlignment="End"
+               VerticalOptions="Center"
+               VerticalTextAlignment="Center"/>
+        <Image VerticalOptions="Center"
+               HorizontalOptions="Center"
+               Source="{Binding Icon}"/>
+      </HorizontalStackLayout>
+    </DataTemplate>
+  </fs:FsTabBarBase.ItemTemplate>
+  <Grid>
+        <Border BackgroundColor="{DynamicResource Amber100}"
+                HorizontalOptions="Fill"
+                VerticalOptions="End"
+                StrokeShape="RoundRectangle 20">
+            <FlexLayout VerticalOptions="End"
+                        Direction="Row"
+                        JustifyContent="SpaceBetween"
+                        AlignContent="Center"
+                        AlignItems="Center"
+                        HorizontalOptions="Fill"
+                        HeightRequest="60"
+                        Margin="0,0,60,0">
+                <Image HeightRequest="55"
+                       WidthRequest="55"
+                       x:Name="EpisodeThumbnail"
+                       Source="{FontImageSource FontFamily=FluentIcons,
+                                                Size=12,
+                                                Glyph={StaticResource IconBot}}"/>
+                
+                <VerticalStackLayout WidthRequest="150"
+                                     x:Name="EpisodeTitleMarquee">
+                    <Label FontAttributes="Bold"
+                           Text="Episode 59: Things"/>
+                    <Label FontSize="Small"
+                           Text="00:15 / 52:43"/>
+                </VerticalStackLayout>
+            </FlexLayout>
+        </Border>
+            
+        <toolkit:Expander VerticalOptions="End"
+                          HorizontalOptions="End"
+                          Direction="Up"
+                          Margin="5"
+                          ExpandedChanged="Expander_OnExpandedChanged">
+            <toolkit:Expander.Header>
+                <Border HeightRequest="50"
+                        WidthRequest="50"
+                        StrokeShape="Ellipse"
+                        Background="{StaticResource GoldGradientBrush}"
+                        HorizontalOptions="End">
+                             <Label Text="{StaticResource IconSparkle}"
+                                    FontFamily="FluentIcons"
+                                    HorizontalOptions="Center"
+                                    VerticalOptions="Center"
+                                    FontSize="24"
+                                    x:Name="SparkleLabel"/>
+                </Border>
+            </toolkit:Expander.Header>
+            <VerticalStackLayout x:Name="TabBar" Spacing="5"/>
+        </toolkit:Expander>
+    </Grid>
+</fs:FsTabBarBase>

--- a/samples/FlagstoneUI.SampleApp/Controls/FloatingTabBar.xaml
+++ b/samples/FlagstoneUI.SampleApp/Controls/FloatingTabBar.xaml
@@ -23,7 +23,7 @@
     </DataTemplate>
   </fs:FsTabBarBase.ItemTemplate>
   <Grid>
-        <Border BackgroundColor="{DynamicResource Amber100}"
+        <Border BackgroundColor="{DynamicResource GoldGradientMiddle}"
                 HorizontalOptions="Fill"
                 VerticalOptions="End"
                 StrokeShape="RoundRectangle 20">

--- a/samples/FlagstoneUI.SampleApp/Controls/FloatingTabBar.xaml.cs
+++ b/samples/FlagstoneUI.SampleApp/Controls/FloatingTabBar.xaml.cs
@@ -1,0 +1,28 @@
+﻿using CommunityToolkit.Maui.Core;
+using FlagstoneUI.Core.Controls;
+
+namespace FlagstoneUI.SampleApp.Controls;
+
+public partial class FloatingTabBar : FsTabBarBase
+{
+	public FloatingTabBar()
+	{
+		InitializeComponent();
+		InitializeTabContainer();
+	}
+
+	protected override Layout TabContainer => TabBar;
+
+	void Expander_OnExpandedChanged(object? sender, ExpandedChangedEventArgs e)
+	{
+		if (e.IsExpanded)
+		{
+			_ = SparkleLabel.RotateToAsync(180);
+		}
+		else
+		{
+			_ = SparkleLabel.RotateToAsync(0);
+		}
+	}
+}
+

--- a/samples/FlagstoneUI.SampleApp/FlagstoneUI.SampleApp.csproj
+++ b/samples/FlagstoneUI.SampleApp/FlagstoneUI.SampleApp.csproj
@@ -91,6 +91,9 @@
 	  <MauiXaml Update="Resources\Styles\Minty.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
+	  <MauiXaml Update="FloatingShell.xaml">
+	    <SubType>Designer</SubType>
+	  </MauiXaml>
 	</ItemGroup>
 
 	<ItemGroup>
@@ -99,6 +102,13 @@
 
 	<ItemGroup Condition="'$(Configuration)' == 'Debug'">
 	  <PackageReference Include="Microsoft.Maui.DevFlow.Agent" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <Compile Update="FloatingShell.xaml.cs">
+	    <DependentUpon>FloatingShell.xaml</DependentUpon>
+	    <SubType>Code</SubType>
+	  </Compile>
 	</ItemGroup>
 
 </Project>

--- a/samples/FlagstoneUI.SampleApp/FloatingShell.xaml
+++ b/samples/FlagstoneUI.SampleApp/FloatingShell.xaml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<fs:FsShell
+  x:Class="FlagstoneUI.SampleApp.FloatingShell"
+  xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+  xmlns:fs="clr-namespace:FlagstoneUI.Core.Controls;assembly=FlagstoneUI.Core"
+  xmlns:controls="clr-namespace:FlagstoneUI.SampleApp.Controls"
+  xmlns:local="clr-namespace:FlagstoneUI.SampleApp"
+  xmlns:page="clr-namespace:FlagstoneUI.SampleApp.Pages"
+  Title="FlagstoneUI.SampleApp">
+  <fs:FsShell.TabBar>
+    <!-- The tab item template lives on FloatingTabBar itself; FsShell.TabBarItemTemplate is only
+         forwarded to the default FsTabBar, so it would be ignored here. -->
+    <controls:FloatingTabBar/>
+  </fs:FsShell.TabBar>
+
+  <!-- Bottom tabs are declared as a single TabBar (one ShellItem with multiple sections) so the
+         FlagstoneUI bar persists while navigating between tabs. The FsTabBar replaces the native
+         BottomNavigationView; no platform code is required of the consumer. -->
+  <TabBar>
+    <ShellContent
+      Title="Controls"
+      Route="ControlsShowcase">
+      <page:ControlsShowcasePage/>
+    </ShellContent>
+
+    <ShellContent
+      Title="Home"
+      Content="{local:MainPage}"
+      Route="MainPage" />
+
+    <ShellContent
+      Title="Sign In"
+      Content="{page:SignInPage}"
+      Route="SignInPage" />
+
+    <ShellContent
+      Title="Editor"
+      Content="{page:FsEditorPage}"
+      Route="FsEditorPage" />
+  </TabBar>
+
+</fs:FsShell>

--- a/samples/FlagstoneUI.SampleApp/FloatingShell.xaml
+++ b/samples/FlagstoneUI.SampleApp/FloatingShell.xaml
@@ -7,7 +7,8 @@
   xmlns:controls="clr-namespace:FlagstoneUI.SampleApp.Controls"
   xmlns:local="clr-namespace:FlagstoneUI.SampleApp"
   xmlns:page="clr-namespace:FlagstoneUI.SampleApp.Pages"
-  Title="FlagstoneUI.SampleApp">
+  Title="FlagstoneUI.SampleApp"
+  TabBarIsDocked="False">
   <fs:FsShell.TabBar>
     <!-- The tab item template lives on FloatingTabBar itself; FsShell.TabBarItemTemplate is only
          forwarded to the default FsTabBar, so it would be ignored here. -->

--- a/samples/FlagstoneUI.SampleApp/FloatingShell.xaml.cs
+++ b/samples/FlagstoneUI.SampleApp/FloatingShell.xaml.cs
@@ -1,0 +1,13 @@
+﻿using FlagstoneUI.Core.Controls;
+using FlagstoneUI.SampleApp.ViewModels;
+
+namespace FlagstoneUI.SampleApp;
+
+public partial class FloatingShell : FsShell
+{
+	public FloatingShell()
+	{
+		InitializeComponent();
+		BindingContext = new AppShellViewModel();
+	}
+}

--- a/src/FlagstoneUI.Core/Platforms/iOS/Controls/FsShellRenderer.cs
+++ b/src/FlagstoneUI.Core/Platforms/iOS/Controls/FsShellRenderer.cs
@@ -41,6 +41,7 @@ internal sealed class FsShellItemRenderer(IShellContext shellContext) : ShellIte
 {
 	private readonly IShellContext _shellContext = shellContext;
 	private UIView? _hostedBar;
+	private UIView? _platformBar;
 	private ContentView? _barContentView;
 	private FsShell? _shell;
 	private NSObject? _kbShowToken;
@@ -139,13 +140,22 @@ internal sealed class FsShellItemRenderer(IShellContext shellContext) : ShellIte
 			return;
 		}
 
-		if (_shell is { TabBarIsDocked: false })
+		var undocked = _shell is { TabBarIsDocked: false };
+		if (bar is PassthroughBarHost host)
+		{
+			// Pass-through is only needed for the full-bounds undocked overlay; a docked bar occupies
+			// just its own bottom strip and should capture touches across it normally.
+			host.PassthroughEnabled = undocked;
+		}
+
+		if (undocked)
 		{
 			var fullFrame = view.Bounds;
 			if (bar.Frame != fullFrame)
 			{
 				bar.Frame = fullFrame;
 			}
+			SyncPlatformBarFrame(bar.Bounds);
 			return;
 		}
 
@@ -178,10 +188,20 @@ internal sealed class FsShellItemRenderer(IShellContext shellContext) : ShellIte
 		{
 			bar.Frame = newFrame;
 		}
+		SyncPlatformBarFrame(bar.Bounds);
 
 		if (_shell?.TabBarIsDocked is null or true && Application.Current is { } app)
 		{
 			app.Resources[FsShell.BottomChromeHeightResourceKey] = (double)height;
+		}
+	}
+
+	/// <summary>Keeps the hosted bar's platform view filling the pass-through host.</summary>
+	private void SyncPlatformBarFrame(CGRect hostBounds)
+	{
+		if (_platformBar is { } platformBar && platformBar.Frame != hostBounds)
+		{
+			platformBar.Frame = hostBounds;
 		}
 	}
 
@@ -200,6 +220,7 @@ internal sealed class FsShellItemRenderer(IShellContext shellContext) : ShellIte
 			}
 
 			_hostedBar = null;
+			_platformBar = null;
 			_barContentView = null;
 			_shell = null;
 		}
@@ -226,31 +247,39 @@ internal sealed class FsShellItemRenderer(IShellContext shellContext) : ShellIte
 			return;
 		}
 
-		var platformBar = bar.ToPlatform(mauiContext);
-
-		// The same bar instance is shared across ShellItem switches; detach it from any previous
-		// host before re-parenting. A UIView may only belong to one superview.
 		var view = View;
 		if (view is null)
 		{
 			return;
 		}
 
-		if (platformBar.Superview is { } prev && !ReferenceEquals(prev, view))
+		var platformBar = bar.ToPlatform(mauiContext);
+
+		// The same bar instance is shared across ShellItem switches; detach it from any previous
+		// host before re-parenting. A UIView may only belong to one superview.
+		if (platformBar.Superview is not null)
 		{
 			platformBar.RemoveFromSuperview();
 		}
 
-		if (platformBar.Superview is null)
+		// Host the bar inside a pass-through container rather than adding it to the view directly.
+		// When undocked the bar spans the whole view (so an overflowing expander has room to draw,
+		// matching Android, which clips to bounds); a plain full-bounds UIView would then swallow
+		// every touch via UIKit hit-testing. The host forwards touches that land on real chrome and
+		// lets taps over the bar's transparent backing fall through to the page beneath. The frame is
+		// set imperatively in LayoutBar; autoresizing-mask coordinates keep the bar in lockstep with
+		// our explicit frame writes without auto-layout fighting for control.
+		var host = new PassthroughBarHost
 		{
-			// The frame is set imperatively in LayoutBar; using autoresizing-mask coordinates
-			// keeps the bar in lockstep with our explicit frame writes without auto-layout fighting
-			// for control.
-			platformBar.TranslatesAutoresizingMaskIntoConstraints = true;
-			view.AddSubview(platformBar);
-		}
+			TranslatesAutoresizingMaskIntoConstraints = true,
+		};
+		platformBar.TranslatesAutoresizingMaskIntoConstraints = true;
+		platformBar.AutoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleHeight;
+		host.AddSubview(platformBar);
+		view.AddSubview(host);
 
-		_hostedBar = platformBar;
+		_hostedBar = host;
+		_platformBar = platformBar;
 		_barContentView = bar;
 	}
 
@@ -338,5 +367,53 @@ internal sealed class FsShellItemRenderer(IShellContext shellContext) : ShellIte
 		}
 
 		return (duration, curve);
+	}
+}
+
+/// <summary>
+/// Hosts the undocked <see cref="FsShell"/> bar as a full-bounds overlay while letting touches that
+/// miss the bar's actual chrome fall through to the page beneath.
+/// </summary>
+/// <remarks>
+/// UIKit's <c>hitTest</c> returns the deepest view containing a point, so a full-bounds interactive
+/// view would swallow every touch on screen — and disabling interaction (<c>InputTransparent</c>)
+/// would instead make the whole bar, including its real controls, untappable. This host resolves the
+/// natural hit and passes through (returns <see langword="null"/>) only when it lands on the bar's
+/// own scaffolding: the host itself, the bar's platform view, or its screen-filling content backing
+/// (the consumer's root layout, which exists to give Android room to draw an overflowing expander).
+/// Real chrome — including the expander's tab list while open — resolves to a deeper view and is
+/// captured normally, so the touchable region tracks the live view tree rather than a static frame.
+/// </remarks>
+internal sealed class PassthroughBarHost : UIView
+{
+	/// <summary>Whether transparent regions pass touches through to views beneath (undocked only).</summary>
+	internal bool PassthroughEnabled { get; set; }
+
+	public override UIView? HitTest(CGPoint point, UIEvent? uievent)
+	{
+		var hit = base.HitTest(point, uievent);
+		if (hit is null || !PassthroughEnabled)
+		{
+			return hit;
+		}
+
+		if (ReferenceEquals(hit, this))
+		{
+			return null;
+		}
+
+		var barView = Subviews.Length > 0 ? Subviews[0] : null;
+		if (ReferenceEquals(hit, barView))
+		{
+			return null;
+		}
+
+		var contentRoot = barView is not null && barView.Subviews.Length > 0 ? barView.Subviews[0] : null;
+		if (ReferenceEquals(hit, contentRoot))
+		{
+			return null;
+		}
+
+		return hit;
 	}
 }

--- a/src/FlagstoneUI.Core/Platforms/iOS/Controls/FsShellRenderer.cs
+++ b/src/FlagstoneUI.Core/Platforms/iOS/Controls/FsShellRenderer.cs
@@ -397,23 +397,19 @@ internal sealed class PassthroughBarHost : UIView
 			return hit;
 		}
 
-		if (ReferenceEquals(hit, this))
-		{
-			return null;
-		}
-
 		var barView = Subviews.Length > 0 ? Subviews[0] : null;
-		if (ReferenceEquals(hit, barView))
-		{
-			return null;
-		}
-
 		var contentRoot = barView is not null && barView.Subviews.Length > 0 ? barView.Subviews[0] : null;
-		if (ReferenceEquals(hit, contentRoot))
+
+		var isScaffolding =
+			ReferenceEquals(hit, this) ||
+			ReferenceEquals(hit, barView) ||
+			ReferenceEquals(hit, contentRoot);
+
+		if (!isScaffolding)
 		{
-			return null;
+			return hit;
 		}
 
-		return hit;
+		return null;
 	}
 }


### PR DESCRIPTION
Floading tab bars had a couple of issues:

1. iOS blocked touch input through to pages
2. Navigation failed on items outside defined bar